### PR TITLE
fix: format string warning by using name.c_str() in RCLCPP_WARN

### DIFF
--- a/src/teleop_acker_joy.cpp
+++ b/src/teleop_acker_joy.cpp
@@ -304,7 +304,7 @@ TeleopAckerJoy::TeleopAckerJoy(const rclcpp::NodeOptions& options) : Node("teleo
       }
       else
       {
-        RCLCPP_WARN(this->get_logger(), "Parameter '%s' is not required and thus is ignored", name);
+        RCLCPP_WARN(this->get_logger(), "Parameter '%s' is not required and thus is ignored", name.c_str());
       }
     }
     return result;


### PR DESCRIPTION


Avoid adding -DCMAKE_CXX_FLAGS=-Wno-error=format=  to CMAKE args.

This change makes the format string and arguments consistent, resolves the compiler warning, and ensures compatibility with stricter compilers.

Thank you